### PR TITLE
Possible reorganization

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,38 @@
+"""
+Author: Alpha-V
+An Example Program That Shows The Usage Of PySO
+"""
+
+import asyncio
+import pyso
+
+def main():
+    """
+    Main body of code - asks for a query to search SO for and attempts to find the answer.
+    """
+
+    query = input("Please enter a search query: ")
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(fetch_result(show_output, query))
+
+async def fetch_result(callback, query):
+    """
+    Fetches The Answer To The Provided Query And Calls The Callback With The Result.
+    """
+
+    search_module = pyso.PySo('YOUR TOKEN HERE')
+    result = await search_module.search(query)
+    callback(result)
+
+def show_output(result):
+    """
+    Prints The Question's Result Out To The User
+    """
+
+    if result is None:
+        print("Unable To Find An Answer!")
+    else:
+        print("{}\n{}\nAnswered by {}".format(result['title'], result['body'], result['answerer']))
+
+if __name__ == '__main__':
+    main()

--- a/pyso/__init__.py
+++ b/pyso/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ['stack_search_module']
 
-from .stack_search_module import pyso
+from .stack_search_module import PySo

--- a/pyso/__init__.py
+++ b/pyso/__init__.py
@@ -1,3 +1,7 @@
+"""
+PySO, A Module That Allows You To Search Stack Overflow Using Python!
+"""
+
 __all__ = ['stack_search_module']
 
 from .stack_search_module import PySo

--- a/pyso/__init__.py
+++ b/pyso/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ['stack_search_module']
 
-from .stack_search_module import search
+from .stack_search_module import pyso

--- a/pyso/helpers.py
+++ b/pyso/helpers.py
@@ -1,8 +1,10 @@
-import aiohttp
-import ujson
+"""
+Helper Functions To Assist PySO To Find Questions And Answers
+"""
+
 import async_timeout
 
-async def fetch_answer(credentials, session, id):
+async def fetch_answer(credentials, session, question_id):
     """
     (internal function) Fetches the json of an answer with the provided id
     session: asyncio HTTP client session
@@ -14,7 +16,7 @@ async def fetch_answer(credentials, session, id):
         params = {'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'filter': '!*c891_gm3k)VJfVnZ1wmTSNzvYc7NzX-F4J3j', 'access_token': credentials[1], 'key': credentials[0]}
 
         # Set up a question get url & call the SE API with this url + the above parameters
-        url = "https://api.stackexchange.com/2.2/answers/" + str(id)
+        url = "https://api.stackexchange.com/2.2/answers/" + str(question_id)
         async with session.get(url, params=params) as resp:
             return await resp.json()
 

--- a/pyso/helpers.py
+++ b/pyso/helpers.py
@@ -1,0 +1,35 @@
+import aiohttp
+import ujson
+import async_timeout
+
+async def fetch_answer(token, session, id):
+    """
+    (internal function) Fetches the json of an answer with the provided id
+    session: asyncio HTTP client session
+    id: id of the answer to look of
+    """
+
+    with async_timeout.timeout(2):
+        # Set up search parameters & a custom filter to get the right fields.
+        params = {'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'filter': '!*c891_gm3k)VJfVnZ1wmTSNzvYc7NzX-F4J3j', 'access_token': access_token, 'key': key}
+
+        # Set up a question get url & call the SE API with this url + the above parameters
+        url = "https://api.stackexchange.com/2.2/answers/" + str(id)
+        async with session.get(url, params=params) as resp:
+            return await resp.json()
+
+async def find_question(token, session, query):
+    """
+    (internal function) Get's the best rated stack overflow question matching the provided query
+    session: asyncio HTTP client session
+    query: text to search SO for
+    """
+
+    with async_timeout.timeout(2):
+        # Set up the parameters and tokens/keys for grabbing a SO answer
+        params = {'page': 1, 'pagesize' : 1, 'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'accepted' : True, 'q': query, 'access_token': access_token, 'key': key}
+        # Set up a search url & call the SE API with this url + the above parameters
+        url = "https://api.stackexchange.com/2.2/search/advanced"
+        async with session.get(url, params=params) as resp:
+            return await resp.json()
+

--- a/pyso/helpers.py
+++ b/pyso/helpers.py
@@ -2,7 +2,7 @@ import aiohttp
 import ujson
 import async_timeout
 
-async def fetch_answer(token, session, id):
+async def fetch_answer(credentials, session, id):
     """
     (internal function) Fetches the json of an answer with the provided id
     session: asyncio HTTP client session
@@ -11,14 +11,14 @@ async def fetch_answer(token, session, id):
 
     with async_timeout.timeout(2):
         # Set up search parameters & a custom filter to get the right fields.
-        params = {'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'filter': '!*c891_gm3k)VJfVnZ1wmTSNzvYc7NzX-F4J3j', 'access_token': access_token, 'key': key}
+        params = {'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'filter': '!*c891_gm3k)VJfVnZ1wmTSNzvYc7NzX-F4J3j', 'access_token': credentials[1], 'key': credentials[0]}
 
         # Set up a question get url & call the SE API with this url + the above parameters
         url = "https://api.stackexchange.com/2.2/answers/" + str(id)
         async with session.get(url, params=params) as resp:
             return await resp.json()
 
-async def find_question(token, session, query):
+async def find_question(credentials, session, query):
     """
     (internal function) Get's the best rated stack overflow question matching the provided query
     session: asyncio HTTP client session
@@ -27,7 +27,7 @@ async def find_question(token, session, query):
 
     with async_timeout.timeout(2):
         # Set up the parameters and tokens/keys for grabbing a SO answer
-        params = {'page': 1, 'pagesize' : 1, 'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'accepted' : True, 'q': query, 'access_token': access_token, 'key': key}
+        params = {'page': 1, 'pagesize' : 1, 'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'accepted' : 'true', 'q': query, 'access_token': credentials[1], 'key': credentials[0]}
         # Set up a search url & call the SE API with this url + the above parameters
         url = "https://api.stackexchange.com/2.2/search/advanced"
         async with session.get(url, params=params) as resp:

--- a/pyso/stack_search_module.py
+++ b/pyso/stack_search_module.py
@@ -6,74 +6,49 @@ import asyncio
 import aiohttp
 import ujson
 import async_timeout
+from .helpers import *
 
-# Stack Exchange API tokens
-# Use https://stackexchange.com/oauth/dialog?client_id=9997&scope=no_expiry&redirect_uri=https://stackexchange.com/oauth/login_success to get an access token tied to your account & the bot's SO app
-access_token = 'SOME_ACCESS_TOKEN_HERE'
-# Probably no need to change this one, unless you want to create your own SO app
-key = 'uKDJS)Ck32rrSYrweVOoOQ(('
-
-async def fetch_answer(session, id):
-    """
-    (internal function) Fetches the json of an answer with the provided id
-    session: asyncio HTTP client session
-    id: id of the answer to look of
-    """
-
-    with async_timeout.timeout(2):
-        # Set up search parameters & a custom filter to get the right fields.
-        params = {'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'filter': '!*c891_gm3k)VJfVnZ1wmTSNzvYc7NzX-F4J3j', 'access_token': access_token, 'key': key}
-
-        # Set up a question get url & call the SE API with this url + the above parameters
-        url = "https://api.stackexchange.com/2.2/answers/" + str(id)
-        async with session.get(url, params=params) as resp:
-            return await resp.json()
-
-async def find_question(session, query):
-    """
-    (internal function) Get's the best rated stack overflow question matching the provided query
-    session: asyncio HTTP client session
-    query: text to search SO for
-    """
-
-    with async_timeout.timeout(2):
-        # Set up the parameters and tokens/keys for grabbing a SO answer
-        params = {'page': 1, 'pagesize' : 1, 'order': 'desc', 'sort': 'votes', 'site': 'stackoverflow', 'accepted' : True, 'q': query, 'access_token': access_token, 'key': key}
-        # Set up a search url & call the SE API with this url + the above parameters
-        url = "https://api.stackexchange.com/2.2/search/advanced"
-        async with session.get(url, params=params) as resp:
-            return await resp.json()
-
-async def search(query):
-    """ 
-    Searches stack overflow for an answer to the provided query and returns a StackAnswer object containing the result.
-    query: Text to search SO for
-    """
-
-    async with aiohttp.ClientSession() as session:
-        # Find a question matching the query
-        question = await find_question(session, query)
-
-        # Grab the the first (top-voted) answer
-        answer_id = question.get("items", [{}])[0].get('accepted_answer_id', -1)
-
-        # Grab the answer's JSON
-        answer = None
-        async with aiohttp.ClientSession() as session_thing:
-            answer = await fetchAnswer(session_thing, answer_id)
+class pyso:
+    def __init__(self, access_token, key='uKDJS)Ck32rrSYrweVOoOQ(('):
+        """
+        Creates a PySO instance that allows you to search Stack Overflow.
         
-        # Convert the answer's JSON into a StackAnswer object
-        answer_dict = {
-                'link': answer.get('items', [{}])[0].get('share_link', "Not Found!"), 
-                'body': answer.get('items', [{}])[0].get('body_markdown', "Not Found!"), 
-                'answerer': answer.get('items', [{}])[0].get('owner', {}).get('display_name', "Not Found!"), 
-                'title': question.get('items', [{}])[0].get('title', "Not Found!"), 
-                'score': answer.get('items', [{}])[0].get('score', "Not Found!"),
-                'answerer_profile_image': answer.get('items', [{}])[0].get('owner', {}).get('profile_image', "https://cdn.discordapp.com/avatars/196989358165852160/b7645b3661eaf16bb2510c2292057890.png?size=256")
-        }
+        access_token: string | your stack exchange access token
+        key: string | your application's key. Default has been set to the PySO app.
+        """
 
-        # Debug log if required
-        #print("Link => {}\nBody => {}\nUsername => {}\nTitle => {}\nScore => {}\n".format(answer['link'], answer['body'], answer['answerer'], answer['title'], answer['score']))
+        self.credentials = (key, access_token)
 
-        return answer_dict
+    async def search(query):
+        """ 
+        Searches stack overflow for an answer to the provided query and returns a StackAnswer object containing the result.
+        query: string | text to search Stack Overflow for
+        """
+
+        async with aiohttp.ClientSession() as session:
+            # Find a question matching the query
+            question = await find_question(session, query)
+
+            # Grab the the first (top-voted) answer
+            answer_id = question.get("items", [{}])[0].get('accepted_answer_id', -1)
+
+            # Grab the answer's JSON
+            answer = None
+            async with aiohttp.ClientSession() as session_thing:
+                answer = await fetchAnswer(session_thing, answer_id)
+            
+            # Convert the answer's JSON into a StackAnswer object
+            answer_dict = {
+                    'link': answer.get('items', [{}])[0].get('share_link', "Not Found!"), 
+                    'body': answer.get('items', [{}])[0].get('body_markdown', "Not Found!"), 
+                    'answerer': answer.get('items', [{}])[0].get('owner', {}).get('display_name', "Not Found!"), 
+                    'title': question.get('items', [{}])[0].get('title', "Not Found!"), 
+                    'score': answer.get('items', [{}])[0].get('score', "Not Found!"),
+                    'answerer_profile_image': answer.get('items', [{}])[0].get('owner', {}).get('profile_image', "https://cdn.discordapp.com/avatars/196989358165852160/b7645b3661eaf16bb2510c2292057890.png?size=256")
+            }
+
+            # Debug log if required
+            #print("Link => {}\nBody => {}\nUsername => {}\nTitle => {}\nScore => {}\n".format(answer['link'], answer['body'], answer['answerer'], answer['title'], answer['score']))
+
+            return answer_dict
 

--- a/pyso/stack_search_module.py
+++ b/pyso/stack_search_module.py
@@ -8,7 +8,7 @@ import ujson
 import async_timeout
 from .helpers import *
 
-class pyso:
+class PySo:
     def __init__(self, access_token, key='uKDJS)Ck32rrSYrweVOoOQ(('):
         """
         Creates a PySO instance that allows you to search Stack Overflow.
@@ -33,18 +33,19 @@ class pyso:
             answer_id = question.get("items", [{}])[0].get('accepted_answer_id', -1)
 
             # Grab the answer's JSON
-            answer = None
-            async with aiohttp.ClientSession() as session_thing:
-                answer = await fetchAnswer(session_thing, answer_id)
+            answer = await fetchAnswer(session, answer_id)
             
+            if answer.get('items', None) == None:
+                return None
+
             # Convert the answer's JSON into a StackAnswer object
             answer_dict = {
-                    'link': answer.get('items', [{}])[0].get('share_link', "Not Found!"), 
-                    'body': answer.get('items', [{}])[0].get('body_markdown', "Not Found!"), 
-                    'answerer': answer.get('items', [{}])[0].get('owner', {}).get('display_name', "Not Found!"), 
-                    'title': question.get('items', [{}])[0].get('title', "Not Found!"), 
-                    'score': answer.get('items', [{}])[0].get('score', "Not Found!"),
-                    'answerer_profile_image': answer.get('items', [{}])[0].get('owner', {}).get('profile_image', "https://cdn.discordapp.com/avatars/196989358165852160/b7645b3661eaf16bb2510c2292057890.png?size=256")
+                    'link': answer['items'][0].get('share_link', "Not Found!"), 
+                    'body': answer['items'][0].get('body_markdown', "Not Found!"), 
+                    'answerer': answer['items'][0].get('owner', {}).get('display_name', "Not Found!"), 
+                    'title': question.get['items'][0].get('title', "Not Found!"), 
+                    'score': answer.get['items'][0].get('score', "Not Found!"),
+                    'answerer_profile_image': answer.get['items'][0].get('owner', {}).get('profile_image', "https://cdn.discordapp.com/avatars/196989358165852160/b7645b3661eaf16bb2510c2292057890.png?size=256")
             }
 
             # Debug log if required

--- a/pyso/stack_search_module.py
+++ b/pyso/stack_search_module.py
@@ -2,17 +2,19 @@
 Author: Alpha-V
 """
 
-import asyncio
 import aiohttp
-import ujson
-import async_timeout
-from .helpers import *
+from .helpers import fetch_answer, find_question
+
 
 class PySo:
+    """
+    Class that allows you to search Stack Overflow.
+    """
+
     def __init__(self, access_token, key='uKDJS)Ck32rrSYrweVOoOQ(('):
         """
         Creates a PySO instance that allows you to search Stack Overflow.
-        
+
         access_token: string | your stack exchange access token
         key: string | your application's key. Default has been set to the PySO app.
         """
@@ -35,17 +37,18 @@ class PySo:
             # Grab the answer's JSON
             answer = await fetch_answer(self.credentials, session, answer_id)
             
-            if answer.get('items', None) == None or len(answer.get('items')) == 0:
+            if answer.get('items', None) is None or len(answer.get('items')) == 0:
                 return None
 
             # Convert the answer's JSON into a StackAnswer object
+            first_answer = answer['items'][0]
             answer_dict = {
-                    'link': answer['items'][0].get('share_link', "Not Found!"), 
-                    'body': answer['items'][0].get('body_markdown', "Not Found!"), 
-                    'answerer': answer['items'][0].get('owner', {}).get('display_name', "Not Found!"), 
-                    'title': question['items'][0].get('title', "Not Found!"), 
-                    'score': answer['items'][0].get('score', "Not Found!"),
-                    'answerer_profile_image': answer['items'][0].get('owner', {}).get('profile_image', "https://cdn.discordapp.com/avatars/196989358165852160/b7645b3661eaf16bb2510c2292057890.png?size=256")
+                'link': first_answer.get('share_link', "Not Found!"), 
+                'body': first_answer.get('body_markdown', "Not Found!"), 
+                'answerer': first_answer.get('owner', {}).get('display_name', "Not Found!"), 
+                'title': question['items'][0].get('title', "Not Found!"), 
+                'score': first_answer.get('score', "Not Found!"),
+                'answerer_profile_image': first_answer.get('owner', {}).get('profile_image', "Not Found!")
             }
 
             # Debug log if required

--- a/pyso/stack_search_module.py
+++ b/pyso/stack_search_module.py
@@ -19,7 +19,7 @@ class PySo:
 
         self.credentials = (key, access_token)
 
-    async def search(query):
+    async def search(self, query):
         """ 
         Searches stack overflow for an answer to the provided query and returns a StackAnswer object containing the result.
         query: string | text to search Stack Overflow for
@@ -27,15 +27,15 @@ class PySo:
 
         async with aiohttp.ClientSession() as session:
             # Find a question matching the query
-            question = await find_question(session, query)
+            question = await find_question(self.credentials, session, query)
 
             # Grab the the first (top-voted) answer
             answer_id = question.get("items", [{}])[0].get('accepted_answer_id', -1)
 
             # Grab the answer's JSON
-            answer = await fetchAnswer(session, answer_id)
+            answer = await fetch_answer(self.credentials, session, answer_id)
             
-            if answer.get('items', None) == None:
+            if answer.get('items', None) == None or len(answer.get('items')) == 0:
                 return None
 
             # Convert the answer's JSON into a StackAnswer object
@@ -43,9 +43,9 @@ class PySo:
                     'link': answer['items'][0].get('share_link', "Not Found!"), 
                     'body': answer['items'][0].get('body_markdown', "Not Found!"), 
                     'answerer': answer['items'][0].get('owner', {}).get('display_name', "Not Found!"), 
-                    'title': question.get['items'][0].get('title', "Not Found!"), 
-                    'score': answer.get['items'][0].get('score', "Not Found!"),
-                    'answerer_profile_image': answer.get['items'][0].get('owner', {}).get('profile_image', "https://cdn.discordapp.com/avatars/196989358165852160/b7645b3661eaf16bb2510c2292057890.png?size=256")
+                    'title': question['items'][0].get('title', "Not Found!"), 
+                    'score': answer['items'][0].get('score', "Not Found!"),
+                    'answerer_profile_image': answer['items'][0].get('owner', {}).get('profile_image', "https://cdn.discordapp.com/avatars/196989358165852160/b7645b3661eaf16bb2510c2292057890.png?size=256")
             }
 
             # Debug log if required

--- a/pyso/stack_search_module.py
+++ b/pyso/stack_search_module.py
@@ -37,7 +37,7 @@ class PySo:
             # Grab the answer's JSON
             answer = await fetch_answer(self.credentials, session, answer_id)
             
-            if answer.get('items', None) is None or len(answer.get('items')) == 0:
+            if not answer.get('items', None):
                 return None
 
             # Convert the answer's JSON into a StackAnswer object

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+asyncio
+aiohttp
+ujson
+async_timeout


### PR DESCRIPTION
An attempt to address points 3 & 4 from this issue: https://github.com/strinking/PySO/issues/1& clean up the interface to the API.
Interface is now to instantiate a `pyso` class with a Stack Exchange API token & optionally a key. Then to call someInstance.search(query). This seperates it into multiple (smaller) classes & gives a cleaner way to handle tokens.